### PR TITLE
obj fixes (windows)

### DIFF
--- a/examples/obj-viewer.cpp
+++ b/examples/obj-viewer.cpp
@@ -53,7 +53,7 @@ public:
     }
 
     void loadObjFile(std::string file){
-        auto pos = file.find_last_of("/")+1;
+        auto pos = file.find_last_of(kPathSeparator)+1;
         auto path = file.substr(0,pos);
         auto filename = file.substr(pos);
         std::cout<<path<<" "<< filename<<std::endl;
@@ -116,6 +116,12 @@ private:
     int i=0;
     glm::vec3 offset{0};
     float farPlane = 100;
+	const char kPathSeparator =
+#ifdef _WIN32
+		'\\';
+#else
+		'/';
+#endif
 };
 
 int main() {

--- a/src/sre/ModelImporter.cpp
+++ b/src/sre/ModelImporter.cpp
@@ -348,7 +348,8 @@ sre::ModelImporter::importObj(std::string path, std::string filename, std::vecto
         vector<string> tokens;
         while (likeTokensizer.good()) {
             likeTokensizer.getline(buffer2, bufferSize, ' ');
-            for (int i=0;i<bufferSize;i++){
+			int buffer2Length = strlen(buffer2);
+            for (int i=0;i<buffer2Length;i++){
                 if (isspace(buffer2[i])){
                     buffer2[i] = '\0';
                 }
@@ -395,7 +396,7 @@ sre::ModelImporter::importObj(std::string path, std::string filename, std::vecto
     int faceCount = 0;
 
     std::vector<ObjInterleavedIndex> indices;
-    ObjInterleavedIndex * currentIndex = &indices.back();
+    ObjInterleavedIndex * currentIndex /*= &indices.back()*/;
     auto materialChange = materialChanges.cbegin();
     bool includeTextureCoordinates = !textureCoords.empty();
     bool includeNormals = !normals.empty();


### PR DESCRIPTION
- objViewer example:
  - parse the .obj file path with the correct OS separator

- sre::ModelImporter::importObj:
  - fixed bug on Windows where the buffer2 buffer were scanned on the uninitialized part
  - remove preemptive initializatoin of currentIndex (vector::back was called on an empty array with undefined behaviour, generate exeption on Windows)