### PR TITLE
Fixed missing search directory in FindGLEW.cmake

### DIFF
--- a/cmake/FindGLEW.cmake
+++ b/cmake/FindGLEW.cmake
@@ -106,6 +106,7 @@ if (${CMAKE_HOST_UNIX})
             /usr/lib64
             /usr/lib
             /usr/local/lib64
+            /usr/lib/x86_64-linux-gnu
             /usr/local/lib
             /sw/lib
             /opt/local/lib


### PR DESCRIPTION
I did a fresh install on Ubuntu Linux (Ubuntu 20.04.1 LTS) and CMake complained that it could not find GLEW. It turns out that the fix had already been made in SimpleRenderEngine/cmake/FindGLEW.cmake, so I just copied that version into SimpleRenderEngineProject/cmake/.